### PR TITLE
Multi Monitor Support for v2.7.0

### DIFF
--- a/Arturo's PTCGPB.ahk
+++ b/Arturo's PTCGPB.ahk
@@ -20,6 +20,7 @@ InitializeJsonFile() ; Create or open the JSON file
     IniRead, Instances, Settings.ini, UserSettings, Instances, 10
 	IniRead, setSpeed, Settings.ini, UserSettings, setSpeed, 2x
     IniRead, defaultLanguage, Settings.ini, UserSettings, defaultLanguage, English
+    IniRead, SelectedMonitorIndex, Settings.ini, UserSettings, SelectedMonitorIndex, 1
 
 ; Main GUI setup
 ; Add the link text at the bottom of the GUI
@@ -65,6 +66,18 @@ if (defaultLanguage = "English") {
 
 Gui, Add, DropDownList, x80 y245 w145 vdefaultLanguage choose%defaultLang%, English|Japanese
 
+; Initialize monitor dropdown options
+SysGet, MonitorCount, MonitorCount
+MonitorOptions := ""
+Loop, %MonitorCount%
+{
+    SysGet, MonitorName, MonitorName, %A_Index%
+    SysGet, Monitor, Monitor, %A_Index%
+    MonitorOptions .= (A_Index > 1 ? "|" : "") "" A_Index ": (" MonitorRight - MonitorLeft "x" MonitorBottom - MonitorTop ")"
+}
+
+Gui, Add, DropDownList, x275 y245 w145 vSelectedMonitorIndex Choose1, %MonitorOptions%
+
 Gui, Add, Edit, vDelay x80 y332 w145 Center, %Delay%
 Gui, Add, Edit, vChangeDate x275 y332 w145 Center, %ChangeDate%
 
@@ -88,8 +101,9 @@ return
 
 ArrangeWindows:
 	GuiControlGet, Instances,, Instances
+    GuiControlGet, SelectedMonitorIndex,, SelectedMonitorIndex
 	Loop %Instances% {
-		resetWindows(A_Index)
+		resetWindows(A_Index, SelectedMonitorIndex)
 		sleep, 10
 	}
 return
@@ -124,6 +138,7 @@ IniWrite, %openPack%, Settings.ini, UserSettings, openPack
 IniWrite, %Instances%, Settings.ini, UserSettings, Instances
 IniWrite, %setSpeed%, Settings.ini, UserSettings, setSpeed
 IniWrite, %defaultLanguage%, Settings.ini, UserSettings, defaultLanguage
+IniWrite, %SelectedMonitorIndex%, Settings.ini, UserSettings, SelectedMonitorIndex
 
 ; Loop to process each instance
 Loop, %Instances%
@@ -159,17 +174,22 @@ Return
 GuiClose:
 ExitApp
 
-resetWindows(Title){
+resetWindows(Title, SelectedMonitorIndex){
 	global Columns
 	if !WinExist(Title)
 		Msgbox, Window titled: %Title% does not exist
-	CreateStatusMessage("Arranging window positions and sizes")
+
+    ; Get monitor origin from index
+    SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
+    SysGet, Monitor, Monitor, %SelectedMonitorIndex%
+    
+	CreateStatusMessage("Arranging window positions and sizes", MonitorLeft, (MonitorTop + 60))
 	rowHeight := 533  ; Adjust the height of each row
 	currentRow := Floor((Title - 1) / Columns)
 	y := currentRow * rowHeight	
 	x := Mod((Title - 1), Columns) * 277
 	
-	WinMove, %Title%, , 0 + x, 0 + y, 277, 537
+	WinMove, %Title%, , % (MonitorLeft + x), % (MonitorTop + y), 277, 537
 	return true
 }
 

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -17,14 +17,15 @@ global winTitle, changeDate, failSafe, openPack, GodPack, Delay, failSafeTime, S
 	winTitle := scriptName
 	pauseToggle := false
 	IniRead, adbPort, %A_ScriptDir%\..\Settings.ini, UserSettings, adbPort%scriptName%, 11111
-    IniRead, Name, %A_ScriptDir%\..\Settings.ini, UserSettings, Name, player1
-    IniRead, Delay, %A_ScriptDir%\..\Settings.ini, UserSettings, Delay, 250
-    IniRead, Variation, %A_ScriptDir%\..\Settings.ini, UserSettings, Variation, 40
-    IniRead, changeDate, %A_ScriptDir%\..\Settings.ini, UserSettings, ChangeDate, 0100
-    IniRead, Columns, %A_ScriptDir%\..\Settings.ini, UserSettings, Columns, 5
-    IniRead, openPack, %A_ScriptDir%\..\Settings.ini, UserSettings, openPack, 4
-    IniRead, setSpeed, %A_ScriptDir%\..\Settings.ini, UserSettings, setSpeed, 2x
+	IniRead, Name, %A_ScriptDir%\..\Settings.ini, UserSettings, Name, player1
+	IniRead, Delay, %A_ScriptDir%\..\Settings.ini, UserSettings, Delay, 250
+	IniRead, Variation, %A_ScriptDir%\..\Settings.ini, UserSettings, Variation, 40
+	IniRead, changeDate, %A_ScriptDir%\..\Settings.ini, UserSettings, ChangeDate, 0100
+	IniRead, Columns, %A_ScriptDir%\..\Settings.ini, UserSettings, Columns, 5
+	IniRead, openPack, %A_ScriptDir%\..\Settings.ini, UserSettings, openPack, 4
+	IniRead, setSpeed, %A_ScriptDir%\..\Settings.ini, UserSettings, setSpeed, 2x
 	IniRead, defaultLanguage, %A_ScriptDir%\..\Settings.ini, UserSettings, defaultLanguage, English
+	IniRead, SelectedMonitorIndex, %A_ScriptDir%\..\Settings.ini, UserSettings, SelectedMonitorIndex, 1:
 	jsonFileName := A_ScriptDir . "\..\json\Packs.json"
 	
 	
@@ -959,17 +960,22 @@ KeepSync(x1, y1, x2, y2, searchVariation := "", imageName := "DEFAULT", clickx :
 
 
 resetWindows(){
-	global Columns, winTitle
+	global Columns, winTitle, SelectedMonitorIndex
 	CreateStatusMessage("Arranging window positions and sizes")
 	if !WinExist(Title)
 		Msgbox, Window titled: %Title% does not exist
+
+	; Get monitor origin from index
+	SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
+	SysGet, Monitor, Monitor, %SelectedMonitorIndex%
+
 	Title := winTitle
 	rowHeight := 533  ; Adjust the height of each row
 	currentRow := Floor((winTitle - 1) / Columns)
 	y := currentRow * rowHeight	
 	x := Mod((winTitle - 1), Columns) * 277
 	
-	WinMove, %Title%, , 0 + x, 0 + y, 277, 537
+	WinMove, %Title%, , % (MonitorLeft + x), % (MonitorTop + y), 277, 537
 	return true
 }
 
@@ -1004,8 +1010,12 @@ LogToFile(message, logFile := "") {
 }
 
 CreateStatusMessage(Message, GuiName := 50, X := 0, Y := 60) {
-	global scriptName, winTitle, statusText
+	global scriptName, winTitle, statusText, SelectedMonitorIndex
 	if WinExist(winTitle) {
+		; Get monitor origin from index
+		SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
+		SysGet, Monitor, Monitor, %SelectedMonitorIndex%
+
 		GuiName := GuiName+scriptName
 		statusText := GuiName+scriptName
 		WinGetPos, xpos, ypos, Width, Height, %winTitle%


### PR DESCRIPTION
Modified version of 2.7.0 that adds multi-monitor support. Accomplished with using **SysGet** and various Monitor sub-commands.

- Added dropdown to GUI to select monitor. (This requires the GUI graphic to be updated still)
- Supports "Arrange Windows" and "Start" instance resizing and positioning.
- Modifies `resetWindows()` to use the selected monitor origin instead of the origin of the primary monitor.
- Adds monitor selection to settings.ini

![image](https://github.com/user-attachments/assets/e99ed208-86a5-44ae-a922-9602a9c85518)
