### PR TITLE
Fix Settings.ini path for new settings in 1.ahk

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -32,9 +32,9 @@ global winTitle, changeDate, failSafe, openPack, Delay, failSafeTime, StartSkipT
 	IniRead, falsePositive, %A_ScriptDir%\..\Settings.ini, UserSettings, falsePositive, No
 	IniRead, skipInvalidGP, %A_ScriptDir%\..\Settings.ini, UserSettings, skipInvalidGP, No
 	IniRead, godPack, %A_ScriptDir%\..\Settings.ini, UserSettings, godPack, 1
-	IniRead, discordWebhookURL, Settings.ini, UserSettings, discordWebhookURL, ""
-    IniRead, discordUserId, Settings.ini, UserSettings, discordUserId, ""
-    IniRead, deleteMethod, Settings.ini, UserSettings, deleteMethod, File
+	IniRead, discordWebhookURL, %A_ScriptDir%\..\Settings.ini, UserSettings, discordWebhookURL, ""
+    IniRead, discordUserId, %A_ScriptDir%\..\Settings.ini, UserSettings, discordUserId, ""
+    IniRead, deleteMethod, %A_ScriptDir%\..\Settings.ini, UserSettings, deleteMethod, File
 	
 	adbPath := folderPath . "\MuMuPlayerGlobal-12.0\shell\adb.exe"
 	


### PR DESCRIPTION
In 1.ahk `discordWebhookURL`, `discordUserId` and `deleteMethod` are using the wrong settings path

It works correctly when starting from PTCGPB.ahk because of global variables, but when starting the scripts separately it fails to retrieve the values