### PR TITLE
Send from each instance when they add main

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -952,6 +952,8 @@ AddFriends() {
 					adbClick(232, 453)
 					if(CheckInstances(165, 250, 190, 275, , "Send", 0)) {
 						adbClick(193, 258)
+						Sendlevel 1
+						send, {F9}
 						break
 					}
 					if(CheckInstances(165, 240, 255, 270, , "Withdraw", 0))
@@ -985,6 +987,8 @@ AddFriends() {
 						}
 					}
 				}
+				Sendlevel 1
+				send, {F9}
 			}
 			KeepSync(120, 500, 155, 530, , "Social", 143, 518, 500)
 			KeepSync(20, 500, 55, 530, , "Home", 40, 516, 500)

--- a/Scripts/Main.ahk
+++ b/Scripts/Main.ahk
@@ -134,6 +134,11 @@ Loop {
 	}
 	Sleep, %Delay%
 	KeepSync(120, 500, 155, 530, , "Social", 143, 518, 1000, 30)
+	Loop {
+		Sleep, %Delay%
+		if(AddFriend > 0)
+			break
+	}
 	KeepSync(226, 100, 270, 135, , "Add", 38, 460, 500)
 	KeepSync(170, 450, 195, 480, , "Approve", 228, 464)
 	done := false
@@ -151,6 +156,8 @@ Loop {
 			}
 		}
 		if(done)
+			Sendlevel 1
+			AddFriend := 0
 			break
 	}
 }
@@ -719,6 +726,7 @@ from_window(ByRef image) {
 ~F5::Reload
 ~F6::Pause
 ~F7::ExitApp
+~F9::FriendAdded()
 
 bboxAndPause(X1, Y1, X2, Y2, doPause := False) {
 	BoxWidth := X2-X1


### PR DESCRIPTION
Added a method similar to the one used in previous versions to notify when the request reaches the main account so it doesn't have to keep spamming buttons because it kinda bothered me.