### PR TITLE
Swap URLDownloadToFile to ComObjCreate

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -1430,7 +1430,16 @@ DownloadFile(url, filename) {
 	url := url  ; Change to your hosted .txt URL "https://pastebin.com/raw/vYxsiqSs"
 	localPath = %A_ScriptDir%\..\%filename% ; Change to the folder you want to save the file
 
-	URLDownloadToFile, %url%, %localPath%
+	; URLDownloadToFile, %url%, %localPath%
+	; Use ComObjCreate as it is less prone to errors.
+	whr := ComObjCreate("WinHttp.WinHttpRequest.5.1")
+	whr.Open("GET", url, true)
+	whr.Send()
+	whr.WaitForResponse()
+	ids := whr.ResponseText
+
+	FileDelete, %localPath%
+	FileAppend, %ids%, %localPath%
 
 	; if ErrorLevel
 		; MsgBox, Download failed!


### PR DESCRIPTION
URLDownloadToFile can fail on some devices (see https://www.autohotkey.com/boards/viewtopic.php?t=62776 )

This method is also an official method, as described in https://www.autohotkey.com/docs/v1/lib/URLDownloadToFile.htm#WHR

The only difference is that we are saving into a variable before writing into file.