### PR TITLE
Ignore potential ids that are not 16 length

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -486,6 +486,10 @@ AddFriends(renew := false, getFC := false) {
 					friendIDs[j] := temp . ""
 				}
 				for index, value in friendIDs {
+					if (StrLen(value) != 16) {
+						; Wrong id value
+						continue
+					}
 					failSafe := A_TickCount
 					failSafeTime := 0
 					Loop {


### PR DESCRIPTION
If someone inputs the wrong id length on some shared id docs this will stop bots from getting stuck.