### PR TITLE
Adding gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Accounts/*
+!Accounts/Saved/1.txt
+!Accounts/*.ahk
+json/*
+!json/1.txt
+Logs/*
+!Logs/1.txt
+Screenshots/*
+!Screenshots/1.txt
+Scripts/*.ahk
+!Scripts/1.ahk
+!Scripts/Main.ahk
+HeartBeat.ini
+Settings.ini


### PR DESCRIPTION
A gitignore file for anyone who chooses to run the bot from the repo folder. Currently only a draft PR as other exlcusions may be needed (e.g. discord.txt, ids.txt, usernames.txt).