### PR TITLE
Instance start delay

### DIFF
--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -23,7 +23,7 @@ CheckForUpdate()
 
 KillADBProcesses()
 
-global Instances, jsonFileName, PacksText, runMain, scaleParam
+global Instances, instanceStartDelay, jsonFileName, PacksText, runMain, scaleParam
 
 totalFile := A_ScriptDir . "\json\total.json"
 backupFile := A_ScriptDir . "\json\total-backup.json"
@@ -54,6 +54,7 @@ IniRead, discordUserId, Settings.ini, UserSettings, discordUserId, ""
 IniRead, Columns, Settings.ini, UserSettings, Columns, 5
 IniRead, godPack, Settings.ini, UserSettings, godPack, Continue
 IniRead, Instances, Settings.ini, UserSettings, Instances, 1
+IniRead, instanceStartDelay, Settings.ini, UserSettings, instanceStartDelay, 0
 IniRead, defaultLanguage, Settings.ini, UserSettings, defaultLanguage, Scale125
 IniRead, SelectedMonitorIndex, Settings.ini, UserSettings, SelectedMonitorIndex, 1
 IniRead, swipeSpeed, Settings.ini, UserSettings, swipeSpeed, 300
@@ -91,19 +92,21 @@ else
 
 Gui, Add, Text, x10 y30, Rerolling Instances:
 Gui, Add, Text, x30 y50, Instances:
-Gui, Add, Edit, vInstances w25 x80 y45 h18, %Instances%
-Gui, Add, Text, x30 y75, Columns:
-Gui, Add, Edit, vColumns w25 x80 y70 h18, %Columns%
+Gui, Add, Edit, vInstances w25 x90 y45 h18, %Instances%
+Gui, Add, Text, x30 y72, Start Delay:
+Gui, Add, Edit, vinstanceStartDelay w25 x90 y67 h18, %instanceStartDelay%
+Gui, Add, Text, x30 y95, Columns:
+Gui, Add, Edit, vColumns w25 x90 y90 h18, %Columns%
 if(runMain)
-	Gui, Add, Checkbox, Checked vrunMain x30 y95, Run Main
+	Gui, Add, Checkbox, Checked vrunMain x30 y115, Run Main
 else
-	Gui, Add, Checkbox, vrunMain x30 y95, Run Main
+	Gui, Add, Checkbox, vrunMain x30 y115, Run Main
 
-Gui, Add, Text, x10 y120, God Pack Settings:
-Gui, Add, Text, x30 y140, Min. 2 Stars:
-Gui, Add, Edit, vminStars w25 x90 y135 h18, %minStars%
+Gui, Add, Text, x10 y135, God Pack Settings:
+Gui, Add, Text, x30 y155, Min. 2 Stars:
+Gui, Add, Edit, vminStars w25 x90 y155 h18, %minStars%
 
-Gui, Add, Text, x10 y160, Method:
+Gui, Add, Text, x10 y180, Method:
 
 ; Pack selection logic
 if (deleteMethod = "5 Pack") {
@@ -114,45 +117,45 @@ if (deleteMethod = "5 Pack") {
 	defaultDelete := 3
 }
 
-Gui, Add, DropDownList, vdeleteMethod gdeleteSettings choose%defaultDelete% x55 y158 w60, 5 Pack|3 Pack|Inject
+Gui, Add, DropDownList, vdeleteMethod gdeleteSettings choose%defaultDelete% x55 y178 w60, 5 Pack|3 Pack|Inject
 
 if(packMethod)
-	Gui, Add, Checkbox, Checked vpackMethod x30 y185, 1 Pack Method
+	Gui, Add, Checkbox, Checked vpackMethod x30 y205, 1 Pack Method
 else
-	Gui, Add, Checkbox, vpackMethod x30 y185, 1 Pack Method
+	Gui, Add, Checkbox, vpackMethod x30 y205, 1 Pack Method
 
 if(nukeAccount)
-	Gui, Add, Checkbox, Checked vnukeAccount x30 y205, Menu Delete Account
+	Gui, Add, Checkbox, Checked vnukeAccount x30 y225, Menu Delete Account
 else
-	Gui, Add, Checkbox, vnukeAccount x30 y205, Menu Delete Account
+	Gui, Add, Checkbox, vnukeAccount x30 y225, Menu Delete Account
 
 if(StrLen(discordUserID) < 3)
 	discordUserID =
 if(StrLen(discordWebhookURL) < 3)
 	discordWebhookURL =
 
-Gui, Add, Text, x10 y225, Discord Settings:
-Gui, Add, Text, x30 y245, Discord ID:
-Gui, Add, Edit, vdiscordUserId w100 x90 y240 h18, %discordUserId%
-Gui, Add, Text, x30 y270, Discord Webhook URL:
-Gui, Add, Edit, vdiscordWebhookURL h20 w100 x150 y265 h18, %discordWebhookURL%
+Gui, Add, Text, x10 y245, Discord Settings:
+Gui, Add, Text, x30 y265, Discord ID:
+Gui, Add, Edit, vdiscordUserId w100 x90 y260 h18, %discordUserId%
+Gui, Add, Text, x30 y290, Discord Webhook URL:
+Gui, Add, Edit, vdiscordWebhookURL h20 w100 x150 y285 h18, %discordWebhookURL%
 
 if(StrLen(heartBeatName) < 3)
 	heartBeatName =
 if(StrLen(heartBeatWebhookURL) < 3)
 	heartBeatWebhookURL =
 if(heartBeat) {
-	Gui, Add, Checkbox, Checked vheartBeat x30 y295 gdiscordSettings, Discord Heartbeat
-	Gui, Add, Text, vhbName x30 y315, Name:
-	Gui, Add, Edit, vheartBeatName w50 x70 y310 h18, %heartBeatName%
-	Gui, Add, Text, vhbURL x30 y340, Webhook URL:
-	Gui, Add, Edit, vheartBeatWebhookURL h20 w100 x110 y335 h18, %heartBeatWebhookURL%
+	Gui, Add, Checkbox, Checked vheartBeat x30 y315 gdiscordSettings, Discord Heartbeat
+	Gui, Add, Text, vhbName x30 y335, Name:
+	Gui, Add, Edit, vheartBeatName w50 x70 y330 h18, %heartBeatName%
+	Gui, Add, Text, vhbURL x30 y360, Webhook URL:
+	Gui, Add, Edit, vheartBeatWebhookURL h20 w100 x110 y355 h18, %heartBeatWebhookURL%
 } else {
-	Gui, Add, Checkbox, vheartBeat x30 y295 gdiscordSettings, Discord Heartbeat
-	Gui, Add, Text, vhbName x30 y315 Hidden, Name:
-	Gui, Add, Edit, vheartBeatName w50 x70 y310 h18 Hidden, %heartBeatName%
-	Gui, Add, Text, vhbURL x30 y340 Hidden, Webhook URL:
-	Gui, Add, Edit, vheartBeatWebhookURL h20 w100 x110 y335 h18 Hidden, %heartBeatWebhookURL%
+	Gui, Add, Checkbox, vheartBeat x30 y315 gdiscordSettings, Discord Heartbeat
+	Gui, Add, Text, vhbName x30 y335 Hidden, Name:
+	Gui, Add, Edit, vheartBeatName w50 x70 y330 h18 Hidden, %heartBeatName%
+	Gui, Add, Text, vhbURL x30 y360 Hidden, Webhook URL:
+	Gui, Add, Edit, vheartBeatWebhookURL h20 w100 x110 y355 h18 Hidden, %heartBeatWebhookURL%
 }
 
 Gui, Add, Text, x275 y10, Choose Pack(s):
@@ -337,6 +340,7 @@ Start:
 	IniWrite, %openPack%, Settings.ini, UserSettings, openPack
 	IniWrite, %godPack%, Settings.ini, UserSettings, godPack
 	IniWrite, %Instances%, Settings.ini, UserSettings, Instances
+	IniWrite, %instanceStartDelay%, Settings.ini, UserSettings, instanceStartDelay
 	;IniWrite, %setSpeed%, Settings.ini, UserSettings, setSpeed
 	IniWrite, %defaultLanguage%, Settings.ini, UserSettings, defaultLanguage
 	IniWrite, %SelectedMonitorIndex%, Settings.ini, UserSettings, SelectedMonitorIndex
@@ -363,6 +367,12 @@ Start:
 	IniWrite, %Mewtwo%, Settings.ini, UserSettings, Mewtwo
 	IniWrite, %slowMotion%, Settings.ini, UserSettings, slowMotion
 
+	; Run main before instances to account for instance start delay
+	if (runMain) {
+		FileName := "Scripts\Main.ahk"
+		Run, %FileName%
+	}
+
 	; Loop to process each instance
 	Loop, %Instances%
 	{
@@ -381,12 +391,14 @@ Start:
 		FileName := "Scripts\" . A_Index . ".ahk"
 		Command := FileName
 
+		if (A_Index != 1 && instanceStartDelay > 0) {
+			instanceStartDelayMS := instanceStartDelay * 1000
+			Sleep, instanceStartDelayMS
+		}
+
 		Run, %Command%
 	}
-	if(runMain) {
-		FileName := "Scripts\Main.ahk"
-		Run, %FileName%
-	}
+
 	if(inStr(FriendID, "https"))
 		DownloadFile(FriendID, "ids.txt")
 	SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")


### PR DESCRIPTION
Adding an optional setting to delay the start of instances >= 2 in an attempt to avoid maxing out underpowered CPUs, which could potentially be the cause of other lag-related issues being reported.