### PR TITLE
feat: Add delete method to enhance pack management (5 packs - no delete)

### DIFF
--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -181,7 +181,10 @@ else if (deleteMethod = "3 Pack")
     defaultDelete := 2
 else if (deleteMethod = "Inject")
     defaultDelete := 3
-Gui, Add, DropDownList, vdeleteMethod gdeleteSettings choose%defaultDelete% x325 y48 w100 Background2A2A2A cWhite, 5 Pack|3 Pack|Inject
+else if (deleteMethod = "5 Pack (Fast)")
+    defaultDelete := 4
+;	SquallTCGP 2025.03.12 - 	Adding the delete method 5 Pack (Fast) to the delete method dropdown list.
+Gui, Add, DropDownList, vdeleteMethod gdeleteSettings choose%defaultDelete% x325 y48 w100 Background2A2A2A cWhite, 5 Pack|3 Pack|Inject|5 Pack (Fast)
 Gui, Add, Checkbox, % (packMethod ? "Checked" : "") " vpackMethod x280 y75 c39FF14", 1 Pack Method
 Gui, Add, Checkbox, % (nukeAccount ? "Checked" : "") " vnukeAccount x280 y95 c39FF14", Menu Delete Account
 

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -239,7 +239,8 @@ if(DeadCheck==1) {
 		if(!injectMethod || !loadedAccount)
 			DoTutorial()
 
-		if(deleteMethod = "5 Pack" || packMethod)
+		;	SquallTCGP 2025.03.12 - 	Adding the delete method 5 Pack (Fast) to the wonder pick check.
+		if(deleteMethod = "5 Pack" || deleteMethod = "5 Pack (Fast)" || packMethod)
 			if(!loadedAccount)
 				wonderPicked := DoWonderPick()
 
@@ -258,7 +259,18 @@ if(DeadCheck==1) {
 			HourglassOpening() ;deletemethod check in here at the start
 
 		if(wonderPicked) {
-			friendsAdded := AddFriends(true)
+			
+			;	SquallTCGP 2025.03.12 - 	Added a check to not add friends if the delete method is 5 Pack (Fast). When using this method (5 Pack (Fast)), 
+			;															it goes to the social menu and clicks the home button to exit (instead of opening all packs directly)
+			; 														just to get around the checking for a level after opening a pack. This change is made based on the 
+			;															5p-no delete community mod created by DietPepperPhD in the discord server.
+
+			if(deleteMethod != "5 Pack (Fast)") {
+				friendsAdded := AddFriends(true)
+			} else {
+				FindImageAndClick(120, 500, 155, 530, , "Social", 143, 518, 500)
+				FindImageAndClick(20, 500, 55, 530, , "Home", 40, 516, 500)
+			}
 			SelectPack("HGPack")
 			PackOpening()
 			if(packMethod) {
@@ -1319,7 +1331,7 @@ FindBorders(prefix) {
 }
 
 FindGodPack() {
-	global winTitle, discordUserId, Delay, username, packs, minStars, scriptName, DeadCheck
+	global winTitle, discordUserId, Delay, username, packs, minStars, scriptName, DeadCheck, deleteMethod
 	gpFound := false
 	invalidGP := false
 	searchVariation := 5
@@ -1331,8 +1343,15 @@ FindGodPack() {
 	}
 	borderCoords := [[20, 284, 90, 286]
 		,[103, 284, 173, 286]]
-	if(packs = 3)
-		packs := 0
+
+	;	SquallTCGP 2025.03.12 - 	Just checking the packs count and setting them to 0 if it's number of packs is 3. 
+	;															This applies to any Delete Method except 5 Pack (Fast). This change is made based 
+	;															on the 5p-no delete community mod created by DietPepperPhD in the discord server.
+	if(deleteMethod != "5 Pack (Fast)") {
+		if(packs = 3)
+			packs := 0
+	}
+
 	Loop {
 		normalBorders := false
 		pBitmap := from_window(WinExist(winTitle))


### PR DESCRIPTION
- This change prevents deleting/readding friends after opening 3 packs. This resulted in a 30% increase in Packs Per Minute (PPM).
- The changes are based on the community mod created by DietPepperPhD in the discord server

I know most rerollers prefer the 3-pack method, but I’ve seen plenty of people who go for the 5-pack instead (including at least 20-30 from my reroller group). Having to copy/paste the community mod by DietPepperPhD every time there’s an update can get a bit annoying—plus, he keeps getting asked about updates in his post. So I thought it’d be nice to have an option for a faster 5-pack method. I kept the original one for those who want to use it as intended by Arturo.