### PR TITLE
fix: Memory leak in Screenshot function

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -1694,8 +1694,9 @@ Screenshot(filename := "Valid") {
 
 	; File path for saving the screenshot locally
 	screenshotFile := screenshotsDir "\" . A_Now . "_" . winTitle . "_" . filename . "_" . packs . "_packs.png"
-	;pBitmap := from_window(WinExist(winTitle))
-	pBitmap := Gdip_CloneBitmapArea(from_window(WinExist(winTitle)), 18, 175, 240, 227)
+	pBitmapW := from_window(WinExist(winTitle))
+	pBitmap := Gdip_CloneBitmapArea(pBitmapW, 18, 175, 240, 227)
+	Gdip_DisposeImage(pBitmapW)
 
 	Gdip_SaveBitmapToFile(pBitmap, screenshotFile)
 


### PR DESCRIPTION
1.ahk:
- The bitmap pointer returned from the `from_window` call is not disposed of, causing the script's memory usage to build up over time.