### PR TITLE
Run multiple main instances

### DIFF
--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -23,7 +23,7 @@ CheckForUpdate()
 
 KillADBProcesses()
 
-global Instances, instanceStartDelay, jsonFileName, PacksText, runMain, scaleParam
+global Instances, instanceStartDelay, jsonFileName, PacksText, runMain, Mains, scaleParam
 
 totalFile := A_ScriptDir . "\json\total.json"
 backupFile := A_ScriptDir . "\json\total-backup.json"
@@ -60,6 +60,7 @@ IniRead, SelectedMonitorIndex, Settings.ini, UserSettings, SelectedMonitorIndex,
 IniRead, swipeSpeed, Settings.ini, UserSettings, swipeSpeed, 300
 IniRead, deleteMethod, Settings.ini, UserSettings, deleteMethod, 3 Pack
 IniRead, runMain, Settings.ini, UserSettings, runMain, 1
+IniRead, Mains, Settings.ini, UserSettings, Mains, 1
 IniRead, heartBeat, Settings.ini, UserSettings, heartBeat, 0
 IniRead, heartBeatWebhookURL, Settings.ini, UserSettings, heartBeatWebhookURL, ""
 IniRead, heartBeatName, Settings.ini, UserSettings, heartBeatName, ""
@@ -111,7 +112,8 @@ Gui, Add, Text, x20 y90 cWhite, Start Delay:
 Gui, Add, Edit, vinstanceStartDelay w50 x105 y88 h20 -E0x200 Background2A2A2A cWhite Center, %instanceStartDelay%
 Gui, Add, Text, x20 y115 cWhite, Columns:
 Gui, Add, Edit, vColumns w50 x105 y113 h20 -E0x200 Background2A2A2A cWhite Center, %Columns%
-Gui, Add, Checkbox, % (runMain ? "Checked" : "") " vrunMain x35 y140 cWhite", Run Main
+Gui, Add, Checkbox, % (runMain ? "Checked" : "") " vrunMain gmainSettings x35 y140 cWhite", Run Main(s)
+Gui, Add, Edit, % "vMains w50 x135 y138 h20 -E0x200 Background2A2A2A cWhite Center" . (runMain ? "" : " Hidden"), %Mains%
 
 ; ========== Time Settings Section ==========
 Gui, Add, GroupBox, x5 y165 w240 h110 c9370DB, Time Settings ; Purple
@@ -309,6 +311,17 @@ CheckForUpdates:
 	CheckForUpdate()
 return
 
+mainSettings:
+	Gui, Submit, NoHide
+
+	if (runMain) {
+		GuiControl, Show, Mains
+	}
+	else {
+		GuiControl, Hide, Mains
+	}
+return
+
 discordSettings:
 	Gui, Submit, NoHide
 
@@ -357,11 +370,13 @@ LaunchAllMumu:
 	GuiControlGet, Instances,, Instances
 	GuiControlGet, folderPath,, folderPath
 	GuiControlGet, runMain,, runMain
+	GuiControlGet, Mains,, Mains
 	GuiControlGet, instanceLaunchDelay,, instanceLaunchDelay
 
 	IniWrite, %Instances%, Settings.ini, UserSettings, Instances
 	IniWrite, %folderPath%, Settings.ini, UserSettings, folderPath
 	IniWrite, %runMain%, Settings.ini, UserSettings, runMain
+	IniWrite, %Mains%, Settings.ini, UserSettings, Mains
 	IniWrite, %instanceLaunchDelay%, Settings.ini, UserSettings, instanceLaunchDelay
 
 	launchAllFile := "LaunchAllMumu.ahk"
@@ -403,6 +418,7 @@ Start:
 	IniWrite, %swipeSpeed%, Settings.ini, UserSettings, swipeSpeed
 	IniWrite, %deleteMethod%, Settings.ini, UserSettings, deleteMethod
 	IniWrite, %runMain%, Settings.ini, UserSettings, runMain
+	IniWrite, %Mains%, Settings.ini, UserSettings, Mains
 	IniWrite, %heartBeat%, Settings.ini, UserSettings, heartBeat
 	IniWrite, %heartBeatWebhookURL%, Settings.ini, UserSettings, heartBeatWebhookURL
 	IniWrite, %heartBeatName%, Settings.ini, UserSettings, heartBeatName

--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -93,14 +93,14 @@ Gui, Font, s10 cWhite, Segoe UI ; Modern font
 
 
 
-; ========== Column 1 ========== 
+; ========== Column 1 ==========
 ; ==============================
 
 ; ========== Friend ID Section ==========
 Gui, Add, GroupBox, x5 y0 w240 h40 cWhite, Friend ID
 if(FriendID = "ERROR" || FriendID = "")
     Gui, Add, Edit, vFriendID w180 x35 y15 h20 -E0x200 Background2A2A2A cWhite
-else 
+else
     Gui, Add, Edit, vFriendID w180 x35 y15 h20 -E0x200 Background2A2A2A cWhite, %FriendID%
 
 ; ========== Instance Settings Section ==========
@@ -190,7 +190,7 @@ Gui, Add, Checkbox, % (autoLaunchMonitor ? "Checked" : "") " vautoLaunchMonitor 
 
 
 
-; ========== Column 2 ========== 
+; ========== Column 2 ==========
 ; ==============================
 
 ; ========== God Pack Settings Section ==========
@@ -200,7 +200,7 @@ Gui, Add, Edit, vminStars w50 x350 y23 h20 -E0x200 Background2A2A2A cWhite Cente
 Gui, Add, Text, x270 y53 c39FF14, Method:
 if (deleteMethod = "5 Pack")
     defaultDelete := 1
-else if (deleteMethod = "3 Pack") 
+else if (deleteMethod = "3 Pack")
     defaultDelete := 2
 else if (deleteMethod = "Inject")
     defaultDelete := 3
@@ -232,15 +232,15 @@ Gui, Add, Checkbox, % (ImmersiveCheck ? "Checked" : "") " vImmersiveCheck x280 y
 
 
 
-; ========== Column 3 ========== 
-; ============================== 
+; ========== Column 3 ==========
+; ==============================
 
 ; ========== Discord Settings Section ==========
 Gui, Add, GroupBox, x505 y0 w240 h120 cFF69B4, Discord Settings ; Hot pink
 if(StrLen(discordUserID) < 3)
     discordUserID =
 if(StrLen(discordWebhookURL) < 3)
-    discordWebhookURL = 
+    discordWebhookURL =
 Gui, Add, Text, x520 y20 cFF69B4, Discord ID:
 Gui, Add, Edit, vdiscordUserId w210 x520 y40 h20 -E0x200 Background2A2A2A cWhite, %discordUserId%
 Gui, Add, Text, x520 y70 cFF69B4, Webhook URL:
@@ -253,7 +253,7 @@ Gui, Add, Checkbox, % (heartBeat ? "Checked" : "") " vheartBeat x520 y145 gdisco
 if(StrLen(heartBeatName) < 3)
     heartBeatName =
 if(StrLen(heartBeatWebhookURL) < 3)
-    heartBeatWebhookURL = 
+    heartBeatWebhookURL =
 
 if (heartBeat) {
     Gui, Add, Text, vhbName x520 y170 c00FFFF, Name:
@@ -268,11 +268,11 @@ if (heartBeat) {
 }
 
 ; ========== Action Buttons ==========
-Gui, Add, Button, gOpenLink x505 y350 w76 h35, Buy Me a Coffee 
-Gui, Add, Button, gCheckForUpdates x588 y350 w77 h35, Check Updates 
-Gui, Add, Button, gOpenDiscord x670 y350 w75 h35, Join Discord 
+Gui, Add, Button, gOpenLink x505 y350 w76 h35, Buy Me a Coffee
+Gui, Add, Button, gCheckForUpdates x588 y350 w77 h35, Check Updates
+Gui, Add, Button, gOpenDiscord x670 y350 w75 h35, Join Discord
 Gui, Add, Button, gStart x505 y280 w240 h30, START BOT
-Gui, Add, Button, gArrangeWindows x630 y315 w115 h30, Arrange Windows 
+Gui, Add, Button, gArrangeWindows x630 y315 w115 h30, Arrange Windows
 Gui, Add, Button, gLaunchAllMumu x505 y315 w115 h30, Launch All Mumu
 
 
@@ -282,7 +282,7 @@ Gui, Add, GroupBox, x255 y385 w490 h110 cWhite, Download Settings ;
 if(StrLen(mainIdsURL) < 3)
     mainIdsURL =
 if(StrLen(vipIdsURL) < 3)
-    vipIdsURL = 
+    vipIdsURL =
 
 Gui, Add, Text, x270 y405 cWhite, ids.txt API:
 Gui, Add, Edit, vmainIdsURL w460 x270 y425 h20 -E0x200 Background2A2A2A cWhite, %mainIdsURL%
@@ -565,7 +565,7 @@ Start:
 					offlineAHK := "Offline: none."
 				if(onlineAHK = "Online: ")
 					onlineAHK := "Online: none."
-				
+
 
 
 				discMessage := "\n" . onlineAHK . "\n" . offlineAHK . "\n" . packStatus

--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -353,12 +353,16 @@ return
 
 ArrangeWindows:
 	GuiControlGet, runMain,, runMain
+	GuiControlGet, Mains,, Mains
 	GuiControlGet, Instances,, Instances
 	GuiControlGet, Columns,, Columns
 	GuiControlGet, SelectedMonitorIndex,, SelectedMonitorIndex
 	if (runMain) {
-		resetWindows("Main", SelectedMonitorIndex)
-		sleep, 10
+		Loop %Mains% {
+			mainInstanceName := "Main" . (A_Index > 1 ? A_Index : "")
+			resetWindows(mainInstanceName, SelectedMonitorIndex)
+			sleep, 10
+		}
 	}
 	Loop %Instances% {
 		resetWindows(A_Index, SelectedMonitorIndex)
@@ -676,8 +680,8 @@ DownloadFile(url, filename) {
 
 }
 
-resetWindows(Title, SelectedMonitorIndex){
-	global Columns, runMain
+resetWindows(Title, SelectedMonitorIndex) {
+	global Columns, runMain, Mains
 	RetryCount := 0
 	MaxRetries := 10
 	Loop
@@ -686,11 +690,13 @@ resetWindows(Title, SelectedMonitorIndex){
 			; Get monitor origin from index
 			SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
 			SysGet, Monitor, Monitor, %SelectedMonitorIndex%
-			if(runMain) {
-				if (Title = "Main") {
-					instanceIndex := 1
+			if (runMain) {
+				if (InStr(Title, "Main") = 1) {
+					instanceIndex := StrReplace(Title, "Main", "")
+					if (instanceIndex = "")
+						instanceIndex := 1
 				} else {
-					instanceIndex := Title + 1
+					instanceIndex := (Mains - 1) + Title + 1
 				}
 			} else {
 				instanceIndex := Title

--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -576,11 +576,13 @@ Start:
 		total := SumVariablesInJsonFile()
 		totalSeconds := Round((A_TickCount - rerollTime) / 1000) ; Total time in seconds
 		mminutes := Floor(totalSeconds / 60)
-		if(total = 0)
-			total := "0                             "
+
 		packStatus := "Time: " . mminutes . "m Packs: " . total
-		packStatus .= " Avg: " . Round(total / mminutes, 2) . " packs/min"
-		CreateStatusMessage(packStatus, 287, 490)
+		packStatus .= "   |   Avg: " . Round(total / mminutes, 2) . " packs/min"
+
+		; Display pack status at the bottom of the first reroll instance
+		CreateStatusMessage(packStatus, ((Mains * scaleParam) + 5), 490)
+
 		if(heartBeat)
 			if((A_Index = 1 || (Mod(A_Index, 60) = 0))) {
 				onlineAHK := "Online: "

--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -471,8 +471,29 @@ Start:
 
 	; Run main before instances to account for instance start delay
 	if (runMain) {
-		FileName := "Scripts\Main.ahk"
-		Run, %FileName%
+		Loop, %Mains%
+		{
+			if (A_Index != 1) {
+				SourceFile := "Scripts\Main.ahk" ; Path to the source .ahk file
+				TargetFolder := "Scripts\" ; Path to the target folder
+				TargetFile := TargetFolder . "Main" . A_Index . ".ahk" ; Generate target file path
+				FileDelete, %TargetFile%
+				FileCopy, %SourceFile%, %TargetFile%, 1 ; Copy source file to target
+				if (ErrorLevel)
+					MsgBox, Failed to create %TargetFile%. Ensure permissions and paths are correct.
+			}
+
+			mainInstanceName := "Main" . (A_Index > 1 ? A_Index : "")
+			FileName := "Scripts\" . mainInstanceName . ".ahk"
+			Command := FileName
+
+			if (A_Index > 1 && instanceStartDelay > 0) {
+				instanceStartDelayMS := instanceStartDelay * 1000
+				Sleep, instanceStartDelayMS
+			}
+
+			Run, %Command%
+		}
 	}
 
 	; Loop to process each instance
@@ -493,7 +514,7 @@ Start:
 		FileName := "Scripts\" . A_Index . ".ahk"
 		Command := FileName
 
-		if (A_Index != 1 && instanceStartDelay > 0) {
+		if ((Mains > 1 || A_Index > 1) && instanceStartDelay > 0) {
 			instanceStartDelayMS := instanceStartDelay * 1000
 			Sleep, instanceStartDelayMS
 		}

--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -432,8 +432,20 @@ Start:
 	IniWrite, %instanceLaunchDelay%, Settings.ini, UserSettings, instanceLaunchDelay
 
 
+	; Using FriendID field to provide a URL to download ids.txt is deprecated.
+    if (inStr(FriendID, "http")) {
+    	MsgBox, To provide a URL for friend IDs, please use the ids.txt API field and leave the Friend ID field empty.
+
+    	if (mainIdsURL = "") {
+			IniWrite, "", Settings.ini, UserSettings, FriendID
+			IniWrite, %FriendID%, Settings.ini, UserSettings, mainIdsURL
+		}
+
+    	Reload
+    }
+
 	; Download a new Main ID file prior to running the rest of the below
-	if(mainIdsURL != "") {
+	if (mainIdsURL != "") {
 		DownloadFile(mainIdsURL, "ids.txt")
 	}
 
@@ -482,8 +494,6 @@ Start:
 		}
 	}
 
-	if(inStr(FriendID, "http"))
-		DownloadFile(FriendID, "ids.txt")
 	SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
 	SysGet, Monitor, Monitor, %SelectedMonitorIndex%
 	rerollTime := A_TickCount

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -754,7 +754,7 @@ FindOrLoseImage(X1, Y1, X2, Y2, searchVariation := "", imageName := "DEFAULT", E
 
 FindImageAndClick(X1, Y1, X2, Y2, searchVariation := "", imageName := "DEFAULT", clickx := 0, clicky := 0, sleepTime := "", skip := false, safeTime := 0) {
 	global winTitle, failSafe, confirmed, slowMotion
-	
+
 	if(slowMotion) {
 		if(imageName = "Platin" || imageName = "One" || imageName = "Two" || imageName = "Three")
 			return true
@@ -1634,7 +1634,7 @@ adbClick(X, Y) {
     static clickCommands := Object()
     static convX := 540/277, convY := 960/489, offset := -44
 
-    key := X << 16 | Y 
+    key := X << 16 | Y
 
     if (!clickCommands.HasKey(key)) {
         clickCommands[key] := Format("input tap {} {}"
@@ -2940,7 +2940,7 @@ createAccountList(instance) {
 			xml := saveDir . "\" . A_LoopFileName
 			FileGetTime, fileTime, %xml%, M
 			timeDiff := A_Now - fileTime  ; Calculate time difference
-			if (timeDiff > 86400) {  ; 24 hours in seconds (60 * 60 * 24) 
+			if (timeDiff > 86400) {  ; 24 hours in seconds (60 * 60 * 24)
 				FileAppend, % A_LoopFileName "`n", %outputTxt%  ; Append file path to output.txt\
 			}
 		}

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -1669,11 +1669,6 @@ DownloadFile(url, filename) {
 }
 
 ReadFile(filename, numbers := false) {
-	global FriendID
-	if(InStr(FriendID, "http")) {
-		DownloadFile(FriendID, "ids.txt")
-		Delay(1)
-	}
 	FileRead, content, %A_ScriptDir%\..\%filename%.txt
 
 	if (!content)

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -16,7 +16,7 @@ CoordMode, Pixel, Screen
 DllCall("AllocConsole")
 WinHide % "ahk_id " DllCall("GetConsoleWindow", "ptr")
 
-global winTitle, changeDate, failSafe, openPack, Delay, failSafeTime, StartSkipTime, Columns, failSafe, adbPort, scriptName, adbShell, adbPath, GPTest, StatusText, defaultLanguage, setSpeed, jsonFileName, pauseToggle, SelectedMonitorIndex, swipeSpeed, godPack, scaleParam, discordUserId, discordWebhookURL, deleteMethod, packs, FriendID, friendIDs, Instances, username, friendCode, stopToggle, friended, runMain, showStatus, injectMethod, packMethod, loadDir, loadedAccount, nukeAccount, TrainerCheck, FullArtCheck, RainbowCheck, dateChange, foundGP, foundTS, friendsAdded, minStars, PseudoGodPack, Palkia, Dialga, Mew, Pikachu, Charizard, Mewtwo, packArray, CrownCheck, ImmersiveCheck, slowMotion, screenShot, accountFile, invalid, starCount, gpFound, foundTS
+global winTitle, changeDate, failSafe, openPack, Delay, failSafeTime, StartSkipTime, Columns, failSafe, adbPort, scriptName, adbShell, adbPath, GPTest, StatusText, defaultLanguage, setSpeed, jsonFileName, pauseToggle, SelectedMonitorIndex, swipeSpeed, godPack, scaleParam, discordUserId, discordWebhookURL, deleteMethod, packs, FriendID, friendIDs, Instances, username, friendCode, stopToggle, friended, runMain, Mains, showStatus, injectMethod, packMethod, loadDir, loadedAccount, nukeAccount, TrainerCheck, FullArtCheck, RainbowCheck, dateChange, foundGP, foundTS, friendsAdded, minStars, PseudoGodPack, Palkia, Dialga, Mew, Pikachu, Charizard, Mewtwo, packArray, CrownCheck, ImmersiveCheck, slowMotion, screenShot, accountFile, invalid, starCount, gpFound, foundTS
 global DeadCheck
 
 scriptName := StrReplace(A_ScriptName, ".ahk")
@@ -42,6 +42,7 @@ IniRead, SelectedMonitorIndex, %A_ScriptDir%\..\Settings.ini, UserSettings, Sele
 IniRead, swipeSpeed, %A_ScriptDir%\..\Settings.ini, UserSettings, swipeSpeed, 300
 IniRead, deleteMethod, %A_ScriptDir%\..\Settings.ini, UserSettings, deleteMethod, 3 Pack
 IniRead, runMain, %A_ScriptDir%\..\Settings.ini, UserSettings, runMain, 1
+IniRead, Mains, %A_ScriptDir%\..\Settings.ini, UserSettings, Mains, 1
 IniRead, heartBeat, %A_ScriptDir%\..\Settings.ini, UserSettings, heartBeat, 0
 IniRead, heartBeatWebhookURL, %A_ScriptDir%\..\Settings.ini, UserSettings, heartBeatWebhookURL, ""
 IniRead, heartBeatName, %A_ScriptDir%\..\Settings.ini, UserSettings, heartBeatName, ""
@@ -920,7 +921,7 @@ LevelUp() {
 }
 
 resetWindows(){
-	global Columns, winTitle, SelectedMonitorIndex, scaleParam, FriendID
+	global Columns, winTitle, SelectedMonitorIndex, scaleParam
 	CreateStatusMessage("Arranging window positions and sizes")
 	RetryCount := 0
 	MaxRetries := 10
@@ -931,33 +932,17 @@ resetWindows(){
 			SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
 			SysGet, Monitor, Monitor, %SelectedMonitorIndex%
 			Title := winTitle
-			rowHeight := 533  ; Height of each row
 
-			if(runMain) {
-				; Calculate currentRow
-				if (winTitle <= Columns - 1) {
-					currentRow := 0  ; First row has (Columns - 1) windows
-				} else {
-					; For rows after the first, adjust calculation
-					adjustedWinTitle := winTitle - (Columns - 1)
-					currentRow := Floor((adjustedWinTitle - 1) / Columns) + 1
-				}
-
-				; Calculate x position
-				if (currentRow == 0) {
-					x := winTitle * scaleParam  ; First row uses (Columns - 1) columns
-				} else {
-					adjustedWinTitle := winTitle - (Columns - 1)
-					x := Mod(adjustedWinTitle - 1, Columns) * scaleParam  ; Subsequent rows use full Columns
-				}
+			if (runMain) {
+				instanceIndex := (Mains - 1) + Title + 1
 			} else {
-				currentRow := Floor((winTitle - 1) / Columns)
-				x := Mod((winTitle - 1), Columns) * scaleParam
+				instanceIndex := Title
 			}
 
+			rowHeight := 533  ; Adjust the height of each row
+			currentRow := Floor((instanceIndex - 1) / Columns)
 			y := currentRow * rowHeight
-
-			; Move the window
+			x := Mod((instanceIndex - 1), Columns) * scaleParam
 			WinMove, %Title%, , % (MonitorLeft + x), % (MonitorTop + y), scaleParam, 537
 			break
 		}

--- a/Scripts/Main.ahk
+++ b/Scripts/Main.ahk
@@ -404,11 +404,15 @@ resetWindows(){
 			SelectedMonitorIndex := RegExReplace(SelectedMonitorIndex, ":.*$")
 			SysGet, Monitor, Monitor, %SelectedMonitorIndex%
 			Title := winTitle
-			rowHeight := 533  ; Adjust the height of each row
-			currentRow := Floor((1 - 1) / Columns)
-			y := currentRow * rowHeight
-			x := Mod((1 - 1), Columns) * scaleParam
 
+			instanceIndex := StrReplace(Title, "Main", "")
+			if (instanceIndex = "")
+				instanceIndex := 1
+
+			rowHeight := 533  ; Adjust the height of each row
+			currentRow := Floor((instanceIndex - 1) / Columns)
+			y := currentRow * rowHeight
+			x := Mod((instanceIndex - 1), Columns) * scaleParam
 			WinMove, %Title%, , % (MonitorLeft + x), % (MonitorTop + y), scaleParam, 537
 			break
 		}

--- a/Scripts/Main.ahk
+++ b/Scripts/Main.ahk
@@ -700,7 +700,7 @@ ToggleTestScript()
 			firstRun := True
 			testStartTime := ""
 		}
-		CreateStatusMessage("Exiting GP Test Mode")		
+		CreateStatusMessage("Exiting GP Test Mode")
 	}
 }
 
@@ -1179,7 +1179,7 @@ RemoveNonVipFriends() {
 					CreateStatusMessage("Couldn't parse friend. Skipping friend...`nParsed friend: " . friendAccount.ToString())
 					LogToFile("Friend skipped: " . friendAccount.ToString() . ". Couldn't parse identifiers.", "GPTestLog.txt")
 				}
-				; If it's a VIP friend, skip removal	
+				; If it's a VIP friend, skip removal
 				if (isVipResult)
 					CreateStatusMessage("Parsed friend: " . friendAccount.ToString() . "`nMatched VIP: " . matchedFriend.ToString() . "`nSkipping VIP...")
 				Sleep, 1500 ; Time to read
@@ -1365,14 +1365,14 @@ ParseFriendAccounts(filePath, ByRef includesIdsAndNames) {
 		line := A_LoopField
 		if (line = "" || line ~= "^\s*$")  ; Skip empty lines
 			continue
-		
+
 		friendCode := ""
 		friendName := ""
 		twoStarCount := ""
 
 		if InStr(line, " | ") {
 			parts := StrSplit(line, " | ") ; Split by " | "
-			
+
 			; Check for ID and Name parts
 			friendCode := Trim(parts[1])
 			friendName := Trim(parts[2])
@@ -1420,14 +1420,14 @@ IsFriendAccountInList(inputFriend, friendList, ByRef matchedFriend) {
 
 IsRecentlyCheckedAccount(inputFriend, ByRef friendList) {
 	if (inputFriend == "") {
-		return false	
+		return false
 	}
-	
+
 	; Check if the account is already in the list
 	if (IsFriendAccountInList(inputFriend, friendList, matchedFriend)) {
 		return true
 	}
-	
+
 	; Add the account to the end of the list
 	friendList.Push(inputFriend)
 


### PR DESCRIPTION
Adding support for running multiple main instances.

Includes:

- A new setting for specifying the number of main instances to run:

![image](https://github.com/user-attachments/assets/7332a664-de62-4c59-918a-022b9ea5c35b)

- Similar to rerolling instances, numbered main instances should be created in MuMu, e.g.:

![image](https://github.com/user-attachments/assets/dd03fbfb-4a55-48e2-a988-e7584093818b)

**NB:** To prevent this from being a breaking change, Main is still 'Main' and not 'Main1'.

- Existing columns setting will account for the number of main instances. When windows are arranged, main instances will be arranged sequentially first, followed by the rerolling instances.

- Existing start delay setting will be used to stagger the start of main instances as well as rerolling instances.

- Updates the configuration and content for the pack status message to ensure it is correctly positioned towards the bottom of the first rerolling instance.

- Fixes a potential conflict when a URL for ids.txt is entered in both the Friend ID field and the ids.txt API field. Prompts the user to use the ids.txt API field if a URL is detected in the Friend ID field, and attempts to automatically update both fields if the ids.txt API field is currently empty.

- Trims trailing whitespace from a few places.