### PR TITLE
Monitor & GP Test Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 sample.png
-MonitorTEST.ahk
-MonitorOnce.ahk
 
 Accounts/*
 !Accounts/Saved/1.txt

--- a/Monitor.ahk
+++ b/Monitor.ahk
@@ -9,8 +9,8 @@ if not A_IsAdmin
     ExitApp
 }
 
-IniRead, instanceLaunchDelay, Settings.ini, UserSettings, instanceLaunchDelay, 5000
-IniRead, waitAfterBulkLaunch, Settings.ini, UserSettings, waitAfterBulkLaunch, 20000
+IniRead, instanceLaunchDelay, Settings.ini, UserSettings, instanceLaunchDelay, 5
+IniRead, waitAfterBulkLaunch, Settings.ini, UserSettings, waitAfterBulkLaunch, 40000
 IniRead, Instances, Settings.ini, UserSettings, Instances, 1
 IniRead, folderPath, Settings.ini, UserSettings, folderPath, C:\Program Files\Netease
 mumuFolder = %folderPath%\MuMuPlayerGlobal-12.0
@@ -40,19 +40,16 @@ Loop {
             
             scriptName := instanceNum . ".ahk"
 
-            pID := checkInstance(instanceNum)
-            if(pID)
-            {
-                killAHK(scriptName)
-                killInstance(instanceNum)
-                Sleep, 3000
-            }
+            killedAHK := killAHK(scriptName)
+            killedInstance := killInstance(instanceNum)
+            Sleep, 3000
             
             pID := checkInstance(instanceNum)
             if not pID {
                 launchInstance(instanceNum)
         
-                Sleep, %instanceLaunchDelay%
+                sleepTime := instanceLaunchDelay * 1000
+                Sleep, % sleepTime
                 launched := launched + 1
 
                 Sleep, %waitAfterBulkLaunch%
@@ -81,6 +78,8 @@ LogToFile(message, logFile) {
 
 killAHK(scriptName := "")
 {
+    killed := 0
+
     if(scriptName != "") {
         DetectHiddenWindows, On
         WinGet, IDList, List, ahk_class AutoHotkey
@@ -92,19 +91,25 @@ killAHK(scriptName := "")
                 ; MsgBox, Killing: %ATitle%
                 WinKill, ahk_id %ID% ;kill
                 ; WinClose, %fullScriptPath% ahk_class AutoHotkey
-                return
+                killed := killed + 1
             }
         }
     }
+
+    return killed
 }
 
 killInstance(instanceNum := "")
 {
-    
+    killed := 0
+
     pID := checkInstance(instanceNum)
     if pID {
         Process, Close, %pID%
+        killed := killed + 1
     }
+
+    return killed
 }
 
 checkInstance(instanceNum := "")

--- a/Monitor.ahk
+++ b/Monitor.ahk
@@ -43,9 +43,10 @@ Loop {
             killedAHK := killAHK(scriptName)
             killedInstance := killInstance(instanceNum)
             Sleep, 3000
-            
+
+            cntAHK := checkAHK(scriptName)            
             pID := checkInstance(instanceNum)
-            if not pID {
+            if not pID && not cntAHK {
                 launchInstance(instanceNum)
         
                 sleepTime := instanceLaunchDelay * 1000
@@ -97,6 +98,26 @@ killAHK(scriptName := "")
     }
 
     return killed
+}
+
+checkAHK(scriptName := "")
+{
+    cnt := 0
+
+    if(scriptName != "") {
+        DetectHiddenWindows, On
+        WinGet, IDList, List, ahk_class AutoHotkey
+        Loop %IDList%
+        {
+            ID:=IDList%A_Index%
+            WinGetTitle, ATitle, ahk_id %ID%
+            if InStr(ATitle, "\" . scriptName) {
+                cnt := cnt + 1
+            }
+        }
+    }
+
+    return cnt
 }
 
 killInstance(instanceNum := "")

--- a/MonitorOnce.ahk
+++ b/MonitorOnce.ahk
@@ -20,55 +20,53 @@ if !FileExist(mumuFolder){
 	MsgBox, 16, , Double check your folder path! It should be the one that contains the MuMuPlayer 12 folder! `nDefault is just C:\Program Files\Netease
 	ExitApp
 }
-Loop {
-    ; Loop through each instance, check if it's started, and start it if it's not
-    launched := 0
 
-    nowEpoch := A_NowUTC
-    EnvSub, nowEpoch, 1970, seconds
+; Loop through each instance, check if it's started, and start it if it's not
+launched := 0
 
-    Loop %Instances% {
-        instanceNum := Format("{:u}", A_Index)
+nowEpoch := A_NowUTC
+EnvSub, nowEpoch, 1970, seconds
 
-        IniRead, LastEndEpoch, %A_ScriptDir%\Scripts\%instanceNum%.ini, Metrics, LastEndEpoch, 0
-        secondsSinceLastEnd := nowEpoch - LastEndEpoch
-        if(LastEndEpoch > 0 && secondsSinceLastEnd > (15 * 60))
-        {
-            ; msgbox, Killing Instance %instanceNum%! Last Run Completed %secondsSinceLastEnd% Seconds Ago
-            msg := "Killing Instance " . instanceNum . "! Last Run Completed " . secondsSinceLastEnd . " Seconds Ago"
-            LogToFile(msg, "Monitor.txt")
-            
-            scriptName := instanceNum . ".ahk"
+Loop %Instances% {
+    instanceNum := Format("{:u}", A_Index)
 
-            killedAHK := killAHK(scriptName)
-            killedInstance := killInstance(instanceNum)
-            Sleep, 3000
-
-            cntAHK := checkAHK(scriptName)            
-            pID := checkInstance(instanceNum)
-            if not pID && not cntAHK {
-                ; Change the last end date to now so that we don't keep trying to restart this beast
-                IniWrite, %nowEpoch%, %A_ScriptDir%\Scripts\%instanceNum%.ini, Metrics, LastEndEpoch
-
-                launchInstance(instanceNum)
+    IniRead, LastEndEpoch, %A_ScriptDir%\Scripts\%instanceNum%.ini, Metrics, LastEndEpoch, 0
+    secondsSinceLastEnd := nowEpoch - LastEndEpoch
+    if(LastEndEpoch > 0 && secondsSinceLastEnd > (15 * 60))
+    {
+        ; msgbox, Killing Instance %instanceNum%! Last Run Completed %secondsSinceLastEnd% Seconds Ago
+        msg := "Killing Instance " . instanceNum . "! Last Run Completed " . secondsSinceLastEnd . " Seconds Ago"
+        LogToFile(msg, "Monitor.txt")
         
-                sleepTime := instanceLaunchDelay * 1000
-                Sleep, % sleepTime
-                launched := launched + 1
+        scriptName := instanceNum . ".ahk"
 
-                Sleep, %waitAfterBulkLaunch%
+        killedAHK := killAHK(scriptName)
+        killedInstance := killInstance(instanceNum)
+        Sleep, 3000
 
-                ;Command := "Scripts\" . scriptName
-                ;Run, %Command%
-			    scriptPath = %A_ScriptDir%\Scripts\%scriptName%
-			    Run "%A_AhkPath%" /restart "%scriptPath%"
-            }
+        cntAHK := checkAHK(scriptName)            
+        pID := checkInstance(instanceNum)
+        if not pID && not cntAHK {
+            ; Change the last end date to now so that we don't keep trying to restart this beast
+            IniWrite, %nowEpoch%, %A_ScriptDir%\Scripts\%instanceNum%.ini, Metrics, LastEndEpoch
+
+            launchInstance(instanceNum)
+    
+            sleepTime := instanceLaunchDelay * 1000
+            Sleep, % sleepTime
+            launched := launched + 1
+
+            Sleep, %waitAfterBulkLaunch%
+
+            ;Command := "Scripts\" . scriptName
+            ;Run, %Command%
+            scriptPath = %A_ScriptDir%\Scripts\%scriptName%
+            Run "%A_AhkPath%" /restart "%scriptPath%"
         }
     }
-
-    ; Check for dead instances every 30 seconds
-    Sleep, 30000
 }
+
+ExitApp
 
 LogToFile(message, logFile) {
 	logFile := A_ScriptDir . "\Logs\" . logFile

--- a/Scripts/Main.ahk
+++ b/Scripts/Main.ahk
@@ -180,10 +180,14 @@ Loop {
 					done := true
 					break
 				} else if(FindOrLoseImage(80, 170, 120, 195, , "player", 0, failSafeTime)) {
+					if (GPTest)
+						break
 					Sleep, %Delay%
 					adbClick(210, 210)
 					Sleep, 1000
 				} else if(FindOrLoseImage(225, 195, 250, 220, , "Pending", 0, failSafeTime)) {
+					if (GPTest)
+						break
 					adbClick(245, 210)
 				} else if(FindOrLoseImage(186, 496, 206, 518, , "Accept", 0, failSafeTime)) {
 					done := true
@@ -690,6 +694,8 @@ ToggleTestScript()
 		triggerTestNeeded := true
 		testStartTime := A_TickCount
 		CreateStatusMessage("In GP Test Mode")
+		StartSkipTime := A_TickCount ;reset stuck timers
+		failSafe := A_TickCount
 	}
 	else {
 		GPTest := false
@@ -1101,28 +1107,15 @@ HoytdjTestScript() {
 }
 
 RemoveNonVipFriends() {
-	global GPTest, vipIdsURL
+	global GPTest, vipIdsURL, failSafe
 	failSafe := A_TickCount
 	failSafeTime := 0
+	; Get us to the Social screen. Won't be super resilient but should be more consistent for most cases.
 	Loop {
 		adbClick(143, 518)
 		if(FindOrLoseImage(120, 500, 155, 530, , "Social", 0, failSafeTime))
 			break
-		else if(FindOrLoseImage(175, 165, 255, 235, , "Hourglass3", 0)) {
-			Delay(3)
-			adbClick(146, 441) ; 146 440
-			Delay(3)
-			adbClick(146, 441)
-			Delay(3)
-			adbClick(146, 441)
-			Delay(3)
-
-			FindImageAndClick(98, 184, 151, 224, , "Hourglass1", 168, 438, 500, 5) ;stop at hourglasses tutorial 2
-			Delay(1)
-
-			adbClick(203, 436) ; 203 436
-		}
-		Sleep, 500
+		Delay(5)
 		failSafeTime := (A_TickCount - failSafe) // 1000
 		CreateStatusMessage("In failsafe for Social. " . failSafeTime "/90 seconds")
 	}

--- a/Scripts/Main.ahk
+++ b/Scripts/Main.ahk
@@ -1289,7 +1289,7 @@ ParseFriendCode(ByRef friendCode) {
 	failSafe := A_TickCount
 	failSafeTime := 0
 	parseFriendCodeResult := False
-	blowUp := [200, 200, 500, 1000, 2000, 100, 250, 300, 350, 400, 450, 550, 600, 700, 800, 900]
+	blowUp := [200, 500, 1000, 2000, 100, 250, 300, 350, 400, 450, 550, 600, 700, 800, 900]
 	Loop {
 		friendCode := GetFriendCode(blowUp[A_Index])
 		if (RegExMatch(friendCode, "^\d{14,17}$")) {
@@ -1297,7 +1297,7 @@ ParseFriendCode(ByRef friendCode) {
 			break
 		}
 		failSafeTime := (A_TickCount - failSafe) // 1000
-		if (failSafeTime > 3) {
+		if (failSafeTime > 4) {
 			parseFriendCodeResult := False
 			break
 		}
@@ -1309,7 +1309,7 @@ ParseFriendName(ByRef friendName) {
 	failSafe := A_TickCount
 	failSafeTime := 0
 	parseFriendNameResult := False
-	blowUp := [200, 200, 500, 1000, 2000, 100, 250, 300, 350, 400, 450, 550, 600, 700, 800, 900]
+	blowUp := [200, 500, 1000, 2000, 100, 250, 300, 350, 400, 450, 550, 600, 700, 800, 900]
 	Loop {
 		friendName := GetFriendName(blowUp[A_Index])
 		if (RegExMatch(friendName, "^[a-zA-Z0-9]{5,20}$")) {
@@ -1317,7 +1317,7 @@ ParseFriendName(ByRef friendName) {
 			break
 		}
 		failSafeTime := (A_TickCount - failSafe) // 1000
-		if (failSafeTime > 2) {
+		if (failSafeTime > 4) {
 			parseFriendNameResult := False
 			break
 		}


### PR DESCRIPTION
- Adjust the Monitor.ahk script to be a bit more resilient (kill the AHK & MuMu every time it detects a run hasn't been completed in > 15 minutes) and fixed a minor issue with the Sleep time being adjusted to be integer seconds as opposed to milliseconds.
- Add a MonitorOnce.ahk script that will auto-boot instances in case you want to test it out and/or don't want to run the one that checks every 15 minutes.
- Adjust Main's GP Test mode to more consistently break out from the Main loop and more consistently/easily return to the Social screen (likely won't solve 100% of edge cases, but this is a mode that is meant to be triggered manually right now regardless).