### PR TITLE
hotfix: prevent infinite Loop in menuDelete function

### DIFF
--- a/PTCGPB.ahk
+++ b/PTCGPB.ahk
@@ -3,9 +3,9 @@ version = Arturos PTCGP Bot
 CoordMode, Mouse, Screen
 SetTitleMatchMode, 3
 
-githubUser := "Arturo-1212"
+githubUser := "papawolf42"
 repoName := "PTCGPB"
-localVersion := "v6.3.24"
+localVersion := "v6.3.24k1"
 scriptFolder := A_ScriptDir
 zipPath := A_Temp . "\update.zip"
 extractPath := A_Temp . "\update"

--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -1062,7 +1062,7 @@ menuDelete() {
 		Loop {
 			clickButton := FindOrLoseImage(75, 340, 195, 530, 40, "Button2", 0, failSafeTime)
 			if(!clickButton) {
-				clickImage := FindOrLoseImage(140, 340, 250, 530, 60, "DeleteAll", 0, failSafeTime)
+				clickImage := FindOrLoseImage(200, 340, 250, 530, 60, "DeleteAll", 0, failSafeTime)
 				if(clickImage) {
 					StringSplit, pos, clickImage, `,  ; Split at ", "
 					adbClick(pos1, pos2)
@@ -1124,7 +1124,7 @@ menuDeleteStart() {
 			Loop {
 				clickButton := FindOrLoseImage(75, 340, 195, 530, 80, "Button", 0, failSafeTime)
 				if(!clickButton) {
-					clickImage := FindOrLoseImage(140, 340, 250, 530, 60, "DeleteAll", 0, failSafeTime)
+					clickImage := FindOrLoseImage(200, 340, 250, 530, 60, "DeleteAll", 0, failSafeTime)
 					if(clickImage) {
 						StringSplit, pos, clickImage, `,  ; Split at ", "
 						adbClick(pos1, pos2)


### PR DESCRIPTION
![snapshot_00 05_ 2025 03 28_15 47 10](https://github.com/user-attachments/assets/bd0de9d4-e7e7-42dd-a5e6-d406e8c89596)
![snapshot_00 06_ 2025 03 28_15 47 50](https://github.com/user-attachments/assets/7505f642-ebf3-474b-b466-4276facb7af9)
Originally, when searching for 'deleteAll,' the top-left coordinate of the detected text overlapped with Button2’s hitbox. This caused Button2 to be clicked by mistake during the 'deleteAll' step, making it disappear. As a result, Button2 couldn't be found, leading to an infinite loop where account deletion succeeded but the next step failed.

To fix this, I adjusted the region of interest (ROI) to avoid unintended overlaps."

