### PR TITLE
Fix `getChangeDateTime()` function

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -216,23 +216,17 @@ if(DeadCheck==1) {
 		openPack := packArray[rand]
 		friended := false
 		IniWrite, 1, %A_ScriptDir%\..\HeartBeat.ini, HeartBeat, Instance%scriptName%
-		FormatTime, CurrentTime,, HHmm
-
-		StartTime := changeDate - 45 ; 12:55 AM2355
-		EndTime := changeDate + 5 ; 1:01 AM
-
-		; Adjust for crossing midnight
-		if (StartTime < 0)
-			StartTime += 2400
-		if (EndTime >= 2400)
-			EndTime -= 2400
+		
+		FormatTime, CurrentTime, %A_NowUTC%, HHmm
+		StartTime := 0555
+		EndTime := 0605
 
 		Random, randomTime, 3, 7
 
 		While(((CurrentTime - StartTime >= 0) && (CurrentTime - StartTime <= randomTime)) || ((EndTime - CurrentTime >= 0) && (EndTime - CurrentTime <= randomTime)))
 		{
 			CreateStatusMessage("I need a break... Sleeping until " . changeDate + randomTime . " `nto avoid being kicked out from the date change")
-			FormatTime, CurrentTime,, HHmm ; Update the current time after sleep
+			FormatTime, CurrentTime, %A_NowUTC%, HHmm ; Update the current time after sleep
 			Sleep, 5000
 			dateChange := true
 		}
@@ -3206,44 +3200,12 @@ DoWonderPick() {
 }
 
 getChangeDateTime() {
-	; Get system timezone bias and determine local time for 1 AM EST
-
-	; Retrieve timezone information from Windows registry
-	RegRead, TimeBias, HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation, Bias
-	RegRead, DltBias, HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation, ActiveTimeBias
-
-	; Convert registry values to integers
-	Bias := TimeBias + 0
-	DltBias := DltBias + 0
-
-	; Determine if Daylight Saving Time (DST) is active
-	IsDST := (Bias != DltBias) ? 1 : 0
-
-	; EST is UTC-5 (300 minutes offset)
-	EST_Offset := 300
-
-	; Use the correct local offset (DST or Standard)
-	Local_Offset := (IsDST) ? DltBias : Bias
-
-	; Convert 1 AM EST to UTC (UTC = EST + 5 hours)
-	UTC_Time := 1 + EST_Offset / 60  ; 06:00 UTC
-
-	; Convert UTC to local time
-	Local_Time := UTC_Time - (Local_Offset / 60)
-
-	; Round to ensure we get whole numbers
-	Local_Time := Floor(Local_Time)
-
-	; Handle 24-hour wrap-around
-	If (Local_Time < 0)
-		Local_Time += 24
-	Else If (Local_Time >= 24)
-		Local_Time -= 24
-
-	; Format output as HHMM
-	FormattedTime := (Local_Time < 10 ? "0" : "") . Local_Time . "00"
-
-	Return FormattedTime
+	offset := A_Now
+	offset -= A_NowUTC, S
+	baseTime := SubStr(A_Now, 1, 8) "0600"
+	EnvAdd, baseTime, %offset%, Seconds
+	FormatTime, output, %baseTime%, HHmm
+	return output
 }
 
 


### PR DESCRIPTION
Since the values stored in `Bias` and `ActiveTimeBias` are unsigned 32-bit integers, and the code expects a negative integer when the UTC offset is positive, the calculation is incorrect because it doesn't convert the unsigned integer to the correct minutes offset. The code should handle this by checking if the MSB is 1 and using `~(offset) + 1` in that case. The attached image shows what happens in the UK, which is currently UTC+1. The same problem happens for all UTC+n countries, making this issue widespread for users in Europe and Asia.

Also simplified the detection of date change crossover using `%A_NowUTC%` so it is standardised for all users. `changeDate` variable remains in the code only because it's used in the status message, can be removed to further simplify.

![image](https://github.com/user-attachments/assets/b5621b7b-9566-483b-890c-83bf277343ab)
![image](https://github.com/user-attachments/assets/00e4dd1c-1663-4fcc-ada5-0adf4e1f1c30)
